### PR TITLE
Add embedded bitcode support

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -17,9 +17,9 @@ The directory structure has to be:
 <pre>
 ./build/ImageMagick-VERSION/       <- ImageMagick top directory
 ./build/IMDelegates/               <- Some delegates: jpeg + png + tiff
-./build/IMDelegates/jpeg-9a/       <- jpeg lib
-./build/IMDelegates/libpng-1.6.10  <- png lib
-./build/IMDelegates/tiff-4.0.3     <- tiff lib
+./build/IMDelegates/jpeg-9b/       <- jpeg lib
+./build/IMDelegates/libpng-1.6.28  <- png lib
+./build/IMDelegates/tiff-4.0.4     <- tiff lib
 </pre>
 
 If you don't have this directory structure you can either create it or try
@@ -29,7 +29,7 @@ or on the respective websites.
 
 The main script to run is:
 <pre>./all.sh VERSION|clean</pre> where VERSION is the version of ImageMagick
-you want to compile (e.g., 6.8.8-9), if 'clean' is passed, the script will
+you want to compile (e.g., 6.8.9-10), if 'clean' is passed, the script will
 clean all the log files and the directories it created.
 
 Upon successful compilation a folder called "IMPORT_ME" will be created from

--- a/env.sh
+++ b/env.sh
@@ -20,6 +20,7 @@ if [ ! -d $DEVROOT ]; then
 fi
 
 # iOS SDK Environmnent
+export SDKMINVER=8.0
 export SDKVER=`xcodebuild -showsdks | fgrep "iphoneos" | tail -n 1 | awk '{print $2}'`
 export DEVROOT=`xcode-select -print-path`/Platforms/iPhoneOS.platform/Developer
 export IOSSDKROOT=$DEVROOT/SDKs/iPhoneOS$SDKVER.sdk
@@ -37,9 +38,9 @@ export IMROOT="$(pwd)"
 export BUILDROOT="$IMROOT/build"
 export IM_DIR="$BUILDROOT/ImageMagick-$IM_VERSION"
 export IM_DELEGATES_DIR="$IM_DIR/IMDelegates/"
-export JPEG_DIR="$IM_DIR/IMDelegates/jpeg-9a"
-export PNG_DIR="$IM_DIR/IMDelegates/libpng-1.6.21"
-export TIFF_DIR="$IM_DIR/IMDelegates/tiff-4.0.4"
+export JPEG_DIR="$IM_DIR/IMDelegates/jpeg-9b"
+export PNG_DIR="$IM_DIR/IMDelegates/libpng-1.6.28"
+export TIFF_DIR="$IM_DIR/IMDelegates/tiff-4.0.7"
 
 # Target directories
 export TARGET_LIB_DIR=$(pwd)/target

--- a/flags.sh
+++ b/flags.sh
@@ -9,15 +9,15 @@ armflags () {
 	export ARM_CFLAGS="-arch $1"
 	export ARM_CFLAGS="$ARM_CFLAGS -I$IOSSDKROOT/usr/include"
 	export ARM_CFLAGS="$ARM_CFLAGS -isysroot $IOSSDKROOT"
-	export ARM_CFLAGS="$ARM_CFLAGS -miphoneos-version-min=$SDKVER"
+	export ARM_CFLAGS="$ARM_CFLAGS -miphoneos-version-min=$SDKMINVER"
 	export ARM_CXXFLAGS="-arch $1"
 	export ARM_CXXFLAGS="$ARM_CFLAGS -I$IOSSDKROOT/usr/include"
 	export ARM_CXXFLAGS="$ARM_CFLAGS -isysroot $IOSSDKROOT"
-	export ARM_CXXFLAGS="$ARM_CFLAGS -miphoneos-version-min=$SDKVER"
+	export ARM_CXXFLAGS="$ARM_CFLAGS -miphoneos-version-min=$SDKMINVER"
 	export ARM_LDFLAGS="-arch $1 -isysroot $IOSSDKROOT"
-	export ARM_LDFLAGS="$ARM_LDFLAGS -miphoneos-version-min=$SDKVER"
+	export ARM_LDFLAGS="$ARM_LDFLAGS -miphoneos-version-min=$SDKMINVER"
 	
-	export ARM_CFLAGS="$ARM_CFLAGS -O3"
+	export ARM_CFLAGS="$ARM_CFLAGS -O3 -fembed-bitcode"
 	# uncomment this line if you want debugging stuff
 	# export ARM_CFLAGS="$ARM_CFLAGS -O0 -g"
 


### PR DESCRIPTION
Also allow minimum iOS SDK version to be specified separately (currently set to 8.0)
Updated expected delegate versions to jpeg-9b, libpng-1.6.28, tiff-4.0.7
Changes were built with ImageMagick 6.8.9-10.  Higher versions do not currently recognize PNG delegate with existing scripts.